### PR TITLE
update import paths to github.com/unravelin

### DIFF
--- a/internal/commandinfo.go
+++ b/internal/commandinfo.go
@@ -12,7 +12,7 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-package internal // import "github.com/garyburd/redigo/internal"
+package internal // import "github.com/unravelin/redigo/internal"
 
 import (
 	"strings"

--- a/internal/redistest/testdb.go
+++ b/internal/redistest/testdb.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/redis"
 )
 
 type testConn struct {

--- a/redis/conn_test.go
+++ b/redis/conn_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
 )
 
 var writeTests = []struct {

--- a/redis/doc.go
+++ b/redis/doc.go
@@ -14,7 +14,7 @@
 
 // Package redis is a client for the Redis database.
 //
-// The Redigo FAQ (https://github.com/garyburd/redigo/wiki/FAQ) contains more
+// The Redigo FAQ (https://github.com/unravelin/redigo/wiki/FAQ) contains more
 // documentation about this package.
 //
 // Connections

--- a/redis/pool.go
+++ b/redis/pool.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/garyburd/redigo/internal"
+	"github.com/unravelin/redigo/internal"
 )
 
 var nowFunc = time.Now // for testing

--- a/redis/pool_test.go
+++ b/redis/pool_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
 )
 
 type poolTestConn struct {

--- a/redis/pubsub_test.go
+++ b/redis/pubsub_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
 )
 
 func publish(channel, value interface{}) {

--- a/redis/reply_test.go
+++ b/redis/reply_test.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
 )
 
 type valueError struct {

--- a/redis/scan_test.go
+++ b/redis/scan_test.go
@@ -16,7 +16,7 @@ package redis_test
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/redis"
 	"math"
 	"reflect"
 	"testing"

--- a/redis/script_test.go
+++ b/redis/script_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
 )
 
 func ExampleScript(c redis.Conn, reply interface{}, err error) {

--- a/redis/zpop_example_test.go
+++ b/redis/zpop_example_test.go
@@ -16,7 +16,7 @@ package redis_test
 
 import (
 	"fmt"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/redis"
 )
 
 // zpop pops a value from the ZSET key using WATCH/MULTI/EXEC commands.

--- a/redisx/connmux.go
+++ b/redisx/connmux.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/garyburd/redigo/internal"
-	"github.com/garyburd/redigo/redis"
+	"github.com/unravelin/redigo/internal"
+	"github.com/unravelin/redigo/redis"
 )
 
 // ConnMux multiplexes one or more connections to a single underlying

--- a/redisx/connmux_test.go
+++ b/redisx/connmux_test.go
@@ -19,9 +19,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/garyburd/redigo/internal/redistest"
-	"github.com/garyburd/redigo/redis"
-	"github.com/garyburd/redigo/redisx"
+	"github.com/unravelin/redigo/internal/redistest"
+	"github.com/unravelin/redigo/redis"
+	"github.com/unravelin/redigo/redisx"
 )
 
 func TestConnMux(t *testing.T) {

--- a/redisx/doc.go
+++ b/redisx/doc.go
@@ -14,4 +14,4 @@
 
 // Package redisx contains experimental features for Redigo. Features in this
 // package may be modified or deleted at any time.
-package redisx // import "github.com/garyburd/redigo/redisx"
+package redisx // import "github.com/unravelin/redigo/redisx"


### PR DESCRIPTION
All import paths point to github.com/unravelin, esp important for internal packages.
